### PR TITLE
Use let* instead of letrec where it isn't needed (and caused problems in...

### DIFF
--- a/monad.scm
+++ b/monad.scm
@@ -56,12 +56,12 @@
 
  (define-syntax do-using 
    (lambda (f r c)
-     (letrec ((name (cadr f))
-              (body (cddr f))
-              (bindf (symbol-append name '-bind))
-              (unitf (symbol-append name '-unit))
-              (failf (symbol-append name '-fail))
-              (name- (symbol-append name '-)))
+     (let* ((name (cadr f))
+            (body (cddr f))
+            (bindf (symbol-append name '-bind))
+            (unitf (symbol-append name '-unit))
+            (failf (symbol-append name '-fail))
+            (name- (symbol-append name '-)))
        `((,(r 'lambda) ()
           (define return ,unitf)
           (define fail ,failf)


### PR DESCRIPTION
... CHICKEN 4.8.2)

Hi Daniel,

Please check out http://tests.call-cc.org/master/linux/x86/2013/08/04/salmonella-report/install/monad.htmlz - this is the nightly automated "Salmonella" test script failing on the monads egg. The reason is that in CHICKEN 4.8.2, we've introduced letrec\* and made regular letrec behave like it is supposed to according to the spec.

In older CHICKENs, letrec was really a letrec_, where later bindings were able to refer to earlier bindings. This is not really something that should be relied upon (the spec forbids it, and most other Schemes will barf on this code). Luckily, letrec(_) is only needed where the bindings concern (mutually) recursive procedures, and in the monads egg the binding form is only creating a few symbols, so it's unnecessary to use letrec there. This patch simply changes letrec to let\* to fix it, which works in all CHICKEN versions.

Please consider accepting this pull request and tagging a new release, so that the tests will succeed and people using 4.8.2 (and in the hopefully not so far future, 4.9.0) will still be able to enjoy this egg!

Cheers,
Peter Bex
